### PR TITLE
Master

### DIFF
--- a/src/Hoverfly.Core.Tests/Dsl/StubServiceBuilder_Test.cs
+++ b/src/Hoverfly.Core.Tests/Dsl/StubServiceBuilder_Test.cs
@@ -1,4 +1,6 @@
-﻿namespace Hoverfly.Core.Tests.Dsl
+﻿using Hoverfly.Core.Model;
+
+namespace Hoverfly.Core.Tests.Dsl
 {
     using System.Linq;
 
@@ -70,6 +72,19 @@
             var pair = pairs.First();
 
             Assert.Equal("POST", pair.Request.Method.ExactMatch);
+        }
+
+        [Fact]
+        public void ShouldCreatePostRequestWithBody()
+        {
+            var pairs = HoverflyDsl.Service("www.my-test.com").Post("/").Body(new FieldMatcher{GlobMatch = "*"}).WillReturn(ResponseBuilder.Response()).RequestResponsePairs;
+
+            Assert.Equal(1, pairs.Count);
+
+            var pair = pairs.First();
+
+            Assert.Equal("POST", pair.Request.Method.ExactMatch);
+            Assert.Equal("*", pair.Request.Body.GlobMatch);
         }
 
         [Fact]

--- a/src/Hoverfly.Core/Dsl/RequestMatcherBuilder.cs
+++ b/src/Hoverfly.Core/Dsl/RequestMatcherBuilder.cs
@@ -18,7 +18,7 @@
         private readonly string _path;
         private readonly string _baseUrl;
         private readonly string _scheme;
-        private string _body = string.Empty;
+        private FieldMatcher _body = new FieldMatcher();
         private readonly Dictionary<string, IList<string>> _headers = new Dictionary<string, IList<string>>();
         private readonly Dictionary<string, IList<string>> _queryParams = new Dictionary<string, IList<string>>();
 
@@ -70,7 +70,7 @@
         /// <returns>Returns this <see cref="RequestMatcherBuilder"/> for further customizations.</returns>
         public RequestMatcherBuilder Body(string body)
         {
-            _body = body;
+            _body = new FieldMatcher(body);
             return this;
         }
 
@@ -81,8 +81,14 @@
         /// <returns>Returns this <see cref="RequestMatcherBuilder"/> for futher customizations.</returns>
         public RequestMatcherBuilder Body(IHttpBodyConverter httpBodyConverter)
         {
-            _body = httpBodyConverter.Body;
+            _body = new FieldMatcher(httpBodyConverter.Body);
             Header(CONTENT_TYPE, httpBodyConverter.ContentType);
+            return this;
+        }
+
+        public RequestMatcherBuilder Body(FieldMatcher bodyMatcher)
+        {
+            _body = bodyMatcher;
             return this;
         }
 
@@ -144,8 +150,8 @@
             _invoker.AddDelay(urlPattern, _dealy.Value, _httpMethod);
             return this;
         }
-        
-        
+
+
         /// <summary>
         /// Sets the expected response.
         /// </summary>

--- a/src/Hoverfly.Core/Dsl/RequestMatcherBuilder.cs
+++ b/src/Hoverfly.Core/Dsl/RequestMatcherBuilder.cs
@@ -86,6 +86,11 @@
             return this;
         }
 
+        /// <summary>
+        /// Sets the request body
+        /// </summary>
+        /// <param name="bodyMatcher">The matcher that is used to match the body</param>
+        /// <returns>Returns this <see cref="RequestMatcherBuilder"/> for further customizations.</returns>
         public RequestMatcherBuilder Body(FieldMatcher bodyMatcher)
         {
             _body = bodyMatcher;

--- a/src/Hoverfly.Core/Model/Request.cs
+++ b/src/Hoverfly.Core/Model/Request.cs
@@ -16,7 +16,7 @@ namespace Hoverfly.Core.Model
             string destination,
             string schema,
             string query,
-            string body,
+            FieldMatcher body,
             Dictionary<string, IList<string>> headers)
         {
             Path = new FieldMatcher(path);
@@ -24,7 +24,7 @@ namespace Hoverfly.Core.Model
             Destination = new FieldMatcher(destination);
             Scheme = new FieldMatcher(schema);
             Query = new FieldMatcher(query);
-            Body = new FieldMatcher(body);
+            Body = body;
             Headers = headers;
         }
 


### PR DESCRIPTION
Changed so that Request Body is a FieldMatcher.
With this change it is possible to create a simulation that matches all/several bodies in a request.

Example:
runner.AddSimulation(Dsl(
                    Service("http://myservice.something.com")
                        .Post("/key/value/three/four")
                        .Body(new FieldMatcher{GlobMatch = "*"})
                        .Header("Content-Type", "application/json")
                        .WillReturn(Success("Hello World!", "plain/text"))))